### PR TITLE
Removed `getValueIgnoringKeyCase` from Object prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const base64 = require("base-64");
 
-module.exports.getValueIgnoringKeyCase = function(lookedObj, lookedKey) {
+module.exports.getValueIgnoringKeyCase = function getValueIgnoringKeyCase(
+  lookedObj,
+  lookedKey
+) {
   return Object.keys(lookedObj)
     .map(
       presentKey =>

--- a/index.js
+++ b/index.js
@@ -1,60 +1,64 @@
-const base64 = require('base-64');
+const base64 = require("base-64");
 
-Object.prototype.getValueIgnoringKeyCase = function(lookedKey) {
-    return Object.keys(this)
-        .map(presentKey => presentKey.toLowerCase() === lookedKey.toLowerCase() ? this[presentKey] : null)
-        .filter(item => item)[0];
+module.exports.getValueIgnoringKeyCase = function(lookedObj, lookedKey) {
+  return Object.keys(lookedObj)
+    .map(
+      presentKey =>
+        presentKey.toLowerCase() === lookedKey.toLowerCase()
+          ? lookedObj[presentKey]
+          : null
+    )
+    .filter(item => item)[0];
 };
 
 module.exports.parse = (event, spotText) => {
-    const boundary = event.headers
-        .getValueIgnoringKeyCase('content-type')
-        .split('=')[1];
-    const body = (event.isBase64Encoded ? base64.decode(event.body) : event.body)
-        .split(new RegExp(boundary))
-        .filter(item => item.match(/Content-Disposition/))
-        .map((item) => {
-            if (item.match(/filename/)) {
-                const result = {};
-                result[
-                    item
-                        .match(/name="[a-zA-Z_]+([a-zA-Z0-9_]*)"/)[0]
-                        .split('=')[1]
-                        .match(/[a-zA-Z_]+([a-zA-Z0-9_]*)/)[0]
-                    ] = {
-                    type: 'file',
-                    filename: item
-                        .match(/filename="[\w-\.]+"/)[0]
-                        .split('=')[1]
-                        .match(/[\w-\.]+/)[0],
-                    contentType: item
-                        .match(/Content-Type: .+\r\n\r\n/)[0]
-                        .replace(/Content-Type: /, '')
-                        .replace(/\r\n\r\n/, ''),
-                    content: (spotText && item
-                        .match(/Content-Type: .+\r\n\r\n/)[0]
-                        .replace(/Content-Type: /, '')
-                        .replace(/\r\n\r\n/, '')
-                            .match(/text/)
-                    )? item
-                        .split(/\r\n\r\n/)[1]
-                        .replace(/\r\n\r\n\r\n--/, ''): new Buffer(item
-                        .split(/\r\n\r\n/)[1]
-                        .replace(/\r\n\r\n\r\n--/, '')),
-                };
-                return result;
-            }
-            const result = {};
-            result[
-                item
-                    .match(/name="[a-zA-Z_]+([a-zA-Z0-9_]*)"/)[0]
-                    .split('=')[1]
-                    .match(/[a-zA-Z_]+([a-zA-Z0-9_]*)/)[0]
-                ] = item
-                .split(/\r\n\r\n/)[1]
-                .split(/\r\n--/)[0];
-            return result;
-        })
-        .reduce((accumulator, current) => Object.assign(accumulator, current), {});
-    return body;
+  const boundary = getValueIgnoringKeyCase(event.headers, "content-type").split(
+    "="
+  )[1];
+  const body = (event.isBase64Encoded ? base64.decode(event.body) : event.body)
+    .split(new RegExp(boundary))
+    .filter(item => item.match(/Content-Disposition/))
+    .map(item => {
+      if (item.match(/filename/)) {
+        const result = {};
+        result[
+          item
+            .match(/name="[a-zA-Z_]+([a-zA-Z0-9_]*)"/)[0]
+            .split("=")[1]
+            .match(/[a-zA-Z_]+([a-zA-Z0-9_]*)/)[0]
+        ] = {
+          type: "file",
+          filename: item
+            .match(/filename="[\w-\.]+"/)[0]
+            .split("=")[1]
+            .match(/[\w-\.]+/)[0],
+          contentType: item
+            .match(/Content-Type: .+\r\n\r\n/)[0]
+            .replace(/Content-Type: /, "")
+            .replace(/\r\n\r\n/, ""),
+          content:
+            spotText &&
+            item
+              .match(/Content-Type: .+\r\n\r\n/)[0]
+              .replace(/Content-Type: /, "")
+              .replace(/\r\n\r\n/, "")
+              .match(/text/)
+              ? item.split(/\r\n\r\n/)[1].replace(/\r\n\r\n\r\n--/, "")
+              : new Buffer(
+                  item.split(/\r\n\r\n/)[1].replace(/\r\n\r\n\r\n--/, "")
+                )
+        };
+        return result;
+      }
+      const result = {};
+      result[
+        item
+          .match(/name="[a-zA-Z_]+([a-zA-Z0-9_]*)"/)[0]
+          .split("=")[1]
+          .match(/[a-zA-Z_]+([a-zA-Z0-9_]*)/)[0]
+      ] = item.split(/\r\n\r\n/)[1].split(/\r\n--/)[0];
+      return result;
+    })
+    .reduce((accumulator, current) => Object.assign(accumulator, current), {});
+  return body;
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 const base64 = require("base-64");
 
-module.exports.getValueIgnoringKeyCase = function getValueIgnoringKeyCase(
-  lookedObj,
-  lookedKey
-) {
+//
+function getValueIgnoringKeyCase(lookedObj, lookedKey) {
   return Object.keys(lookedObj)
     .map(
       presentKey =>
@@ -12,8 +10,11 @@ module.exports.getValueIgnoringKeyCase = function getValueIgnoringKeyCase(
           : null
     )
     .filter(item => item)[0];
-};
+}
+//
+module.exports.getValueIgnoringKeyCase = getValueIgnoringKeyCase;
 
+//
 module.exports.parse = (event, spotText) => {
   const boundary = getValueIgnoringKeyCase(event.headers, "content-type").split(
     "="


### PR DESCRIPTION
Caused issues with libraries doing strict object validation.

Ticket: https://github.com/myshenin/aws-lambda-multipart-parser/issues/7

Another discussion about this type of issue https://github.com/aws/aws-sdk-js/issues/575