### PR TITLE
Decode event body from BASE 64

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,11 @@ function getBoundary(event) {
 module.exports.parse = (event, spotText) => {
     const boundary = getBoundary(event);
     const result = {};
-    event.body
+    // Decode body from BASE64
+    const data = event.body;  
+    const buff = new Buffer(data, 'base64');  
+    const eventBody = buff.toString('ascii');
+    eventBody
         .split(boundary)
         .forEach(item => {
             if (/filename=".+"/g.test(item)) {


### PR DESCRIPTION
@myshenin I was only able to get this working by decoding the `event.body` from base64 prior to being introduced to your pattern matching logic. My event object comes from AWS API Gateway as a base64 encoded string. 