### PR TITLE
Makes list on repeated fieldnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,17 @@ module.exports.parse = (event, spotText) => {
                         item.slice(item.search(/Content-Type:\s.+/g) + item.match(/Content-Type:\s.+/g)[0].length + 4, -4),
                 };
             } else if (/name=".+"/g.test(item)){
-                result[item.match(/name=".+"/g)[0].slice(6, -1)] = item.slice(item.search(/name=".+"/g) + item.match(/name=".+"/g)[0].length + 4, -4);
+                const fieldname = item.match(/name=".+"/g)[0].slice(6, -1);
+                const val = item.slice(item.search(/name=".+"/g) + item.match(/name=".+"/g)[0].length + 4, -4);              
+
+                if (fieldname in result) {
+                    if (!Array.isArray(result[fieldname])) {
+                        result[fieldname] = [result[fieldname]]
+                    }
+                    result[fieldname].push(val)
+                } else {
+                    result[fieldname] = val
+                }
             }
         });
     return result;


### PR DESCRIPTION
This change allows repeated fieldnames to not override the previous one.
Instead, if it checks that the fieldname was already parsed, it will make it into a list, and push the new value
This would be a solution for this issue: https://github.com/myshenin/aws-lambda-multipart-parser/issues/23